### PR TITLE
fix(patient_appointment):cancel_sales_invoice

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -418,8 +418,9 @@ def cancel_appointment(appointment_id):
 def cancel_sales_invoice(sales_invoice):
 	if frappe.db.get_single_value("Healthcare Settings", "automate_appointment_invoicing"):
 		if len(sales_invoice.items) == 1:
-			sales_invoice.cancel()
-			return True
+			if sales_invoice.docstatus == 1:
+				sales_invoice.cancel()
+				return True
 	return False
 
 


### PR DESCRIPTION
add extra condition when canceling linked sales invoice when the sales invoice is draft
Case:
=> I faced a situation with a patient appointment doctype when I tried to cancel it and there was a linked sales invoice, in the case when I want to cancel the patient appointment and the sales invoice is not submitted yet, then the existing cancel function will show an error when trying to cancel a submitted invoice